### PR TITLE
Fixed interface in libcamera_app.hpp

### DIFF
--- a/include/libcamera_app.hpp
+++ b/include/libcamera_app.hpp
@@ -50,7 +50,7 @@ public:
 	using CameraConfiguration = libcamera::CameraConfiguration;
 	using FrameBufferAllocator = libcamera::FrameBufferAllocator;
 	using StreamRole = libcamera::StreamRole;
-	using StreamRoles = libcamera::StreamRoles;
+	using StreamRoles = std::vector<libcamera::StreamRole>;
 	using PixelFormat = libcamera::PixelFormat;
 	using StreamConfiguration = libcamera::StreamConfiguration;
 	using BufferMap = Request::BufferMap;


### PR DESCRIPTION
The current version of LCCV doesn't compile against the recent libcamera version.

In libcamera the definition of StreamRoles changed to std::vector<libcamera::StreamRole>

As shown here: https://github.com/raspberrypi/libcamera-apps/blob/a8e6df7bf18c0e418d7f220ba6fd84788f3a691a/core/libcamera_app.hpp#L56C2-L56C2