### PR TITLE
gcc12 compatability fixes.

### DIFF
--- a/src/lccv.cpp
+++ b/src/lccv.cpp
@@ -99,7 +99,7 @@ bool PiCamera::capturePhoto(cv::Mat &frame)
 bool PiCamera::startVideo()
 {
     if(camerastarted)stopPhoto();
-    if(running.load(std::memory_order_release)){
+    if(running.load(std::memory_order_relaxed)){
         std::cerr<<"Video thread already running";
         return false;
     }

--- a/src/libcamera_app.cpp
+++ b/src/libcamera_app.cpp
@@ -307,7 +307,6 @@ void LibcameraApp::queueRequest(CompletedRequest *completed_request)
 	BufferMap buffers(std::move(completed_request->buffers));
 
 	Request *request = completed_request->request;
-	delete completed_request;
 	assert(request);
 
 	// This function may run asynchronously so needs protection from the
@@ -321,6 +320,7 @@ void LibcameraApp::queueRequest(CompletedRequest *completed_request)
 	{
 		std::lock_guard<std::mutex> lock(completed_requests_mutex_);
 		auto it = completed_requests_.find(completed_request);
+        delete completed_request;
 		if (it == completed_requests_.end())
 			return;
 		completed_requests_.erase(it);


### PR DESCRIPTION
By default, Bookworm utilizes gcc 12. Therefore, I have updated the code to ensure compatibility with this version. Although I haven't tested it with earlier OS versions, I believe it should still function properly. (requires testing)

Closes #25 
Closes #24