### PR TITLE
Supports Multiple Cameras Now

### DIFF
--- a/example/takevideo.cpp
+++ b/example/takevideo.cpp
@@ -1,28 +1,52 @@
 #include <lccv.hpp>
+#include <libcamera_app.hpp>
 #include <opencv2/opencv.hpp>
 
-int main()
-{
+int main() {
+	uint32_t num_cams = LibcameraApp::GetNumberCameras();
+	std::cout << "Found " << num_cams << " cameras." << std::endl;
+
+    uint32_t height = 480;
+    uint32_t width = 640;
     std::cout<<"Sample program for LCCV video capture"<<std::endl;
     std::cout<<"Press ESC to stop."<<std::endl;
-    cv::Mat image;
+    cv::Mat image = cv::Mat(height, width, CV_8UC3);
+    cv::Mat image2 = cv::Mat(height, width, CV_8UC3);
     lccv::PiCamera cam;
-    cam.options->video_width=1024;
-    cam.options->video_height=768;
-    cam.options->framerate=5;
+    cam.options->video_width=width;
+    cam.options->video_height=height;
+    cam.options->framerate=30;
     cam.options->verbose=true;
     cv::namedWindow("Video",cv::WINDOW_NORMAL);
     cam.startVideo();
+
+	lccv::PiCamera cam2(1);
+	cam2.options->video_width=width;
+	cam2.options->video_height=height;
+	cam2.options->framerate=30;
+	cam2.options->verbose=true;
+	if (1 < num_cams) {
+		cam2.startVideo();
+	}
+
     int ch=0;
     while(ch!=27){
-        if(!cam.getVideoFrame(image,1000)){
+        if (!cam.getVideoFrame(image,1000)){
             std::cout<<"Timeout error"<<std::endl;
-        }
-        else{
-            cv::imshow("Video",image);
-            ch=cv::waitKey(10);
-        }
+        } else {
+			cv::imshow("Video1",image);
+		}
+		if (1 < num_cams) {
+			if (!cam2.getVideoFrame(image2,1000)){
+				std::cout<<"Timeout2 error"<<std::endl;
+			} else {
+				cv::imshow("Video2",image2);
+			}
+		}
+        ch=cv::waitKey(5);
     }
+
     cam.stopVideo();
-    cv::destroyWindow("Video");
+	cam2.stopVideo();
+	cv::destroyAllWindows();
 }

--- a/include/lccv.hpp
+++ b/include/lccv.hpp
@@ -14,6 +14,7 @@ namespace lccv {
 class PiCamera {
 public:
     PiCamera();
+    PiCamera(uint32_t id);
     ~PiCamera();
 
     Options *options;
@@ -33,8 +34,8 @@ public:
 
 protected:
     void run();
-protected:
-    LibcameraApp *app;
+
+	std::unique_ptr<LibcameraApp> app;
     void getImage(cv::Mat &frame, CompletedRequestPtr &payload);
     static void *videoThreadFunc(void *p);
     pthread_t videothread;

--- a/include/libcamera_app.hpp
+++ b/include/libcamera_app.hpp
@@ -90,6 +90,7 @@ public:
 	virtual ~LibcameraApp();
 
 	Options *GetOptions() const { return options_.get(); }
+	static uint32_t GetNumberCameras();
 
 	std::string const &CameraId() const;
 	void OpenCamera();
@@ -126,6 +127,19 @@ protected:
 	std::unique_ptr<Options> options_;
 
 private:
+	static std::shared_ptr<CameraManager> getCameraManager() {
+		static std::shared_ptr<CameraManager> camera_manager_;
+		if (!camera_manager_) {
+			camera_manager_ = std::make_shared<CameraManager>();
+			int ret = camera_manager_->start();
+			if (ret)
+				throw std::runtime_error("camera manager failed to start,"
+					"code " + std::to_string(-ret));
+		}
+
+		return camera_manager_;
+	}
+
 	template <typename T>
 	class MessageQueue
 	{
@@ -163,7 +177,6 @@ private:
 	void requestComplete(Request *request);
 	void configureDenoise(const std::string &denoise_mode);
 
-	std::unique_ptr<CameraManager> camera_manager_;
 	std::shared_ptr<Camera> camera_;
 	bool camera_acquired_ = false;
 	std::unique_ptr<CameraConfiguration> configuration_;

--- a/src/lccv.cpp
+++ b/src/lccv.cpp
@@ -5,11 +5,13 @@
 using namespace cv;
 using namespace lccv;
 
-PiCamera::PiCamera()
-{
-    app = new LibcameraApp(std::make_unique<Options>());
+PiCamera::PiCamera() : PiCamera(0) {}
+
+PiCamera::PiCamera(uint32_t id) {
+	app = std::make_unique<LibcameraApp>(std::make_unique<Options>());
     options = static_cast<Options *>(app->GetOptions());
     still_flags = LibcameraApp::FLAG_STILL_NONE;
+	options->camera = id;
     options->photo_width = 4056;
     options->photo_height = 3040;
     options->video_width = 640;
@@ -29,17 +31,15 @@ PiCamera::PiCamera()
     camerastarted=false;
 }
 
-PiCamera::~PiCamera()
-{
-    delete app;
-}
+PiCamera::~PiCamera() {}
 
 void PiCamera::getImage(cv::Mat &frame, CompletedRequestPtr &payload)
 {
     unsigned int w, h, stride;
     libcamera::Stream *stream = app->StillStream();
 	app->StreamDimensions(stream, &w, &h, &stride);
-    const std::vector<libcamera::Span<uint8_t>> mem = app->Mmap(payload->buffers[stream]);
+    const std::vector<libcamera::Span<uint8_t>> mem =
+			app->Mmap(payload->buffers[stream]);
     frame.create(h,w,CV_8UC3);
     uint ls = w*3;
     uint8_t *ptr = (uint8_t *)mem[0].data();

--- a/src/libcamera_app.cpp
+++ b/src/libcamera_app.cpp
@@ -29,24 +29,23 @@ std::string const &LibcameraApp::CameraId() const
 	return camera_->id();
 }
 
+uint32_t LibcameraApp::GetNumberCameras() {
+	return getCameraManager()->cameras().size();
+}
+
 void LibcameraApp::OpenCamera()
 {
 
 	if (options_->verbose)
 		std::cerr << "Opening camera..." << std::endl;
 
-	camera_manager_ = std::make_unique<CameraManager>();
-	int ret = camera_manager_->start();
-	if (ret)
-		throw std::runtime_error("camera manager failed to start, code " + std::to_string(-ret));
-
-	if (camera_manager_->cameras().size() == 0)
+	if (getCameraManager()->cameras().size() == 0)
 		throw std::runtime_error("no cameras available");
-	if (options_->camera >= camera_manager_->cameras().size())
+	if (options_->camera >= getCameraManager()->cameras().size())
 		throw std::runtime_error("selected camera is not available");
 
-	std::string const &cam_id = camera_manager_->cameras()[options_->camera]->id();
-	camera_ = camera_manager_->get(cam_id);
+	std::string const &cam_id = getCameraManager()->cameras()[options_->camera]->id();
+	camera_ = getCameraManager()->get(cam_id);
 	if (!camera_)
 		throw std::runtime_error("failed to find camera " + cam_id);
 
@@ -66,8 +65,6 @@ void LibcameraApp::CloseCamera()
 	camera_acquired_ = false;
 
 	camera_.reset();
-
-	camera_manager_.reset();
 
 	if (options_->verbose && !options_->help)
 		std::cerr << "Camera closed" << std::endl;


### PR DESCRIPTION
LCCV currently can't handle 2 camera streams simultaneously. Since the CameraManager was a raw pointer it was blocking additional PiCamera instances from being made. This allows me/us to use multiple cameras for stereo processing.

I'm not entirely sure the CameraManager is being shut down properly right now, but it hasn't been giving me issues this way.