### PR TITLE
Don't overwrite request controls for libcamera 0.7

### DIFF
--- a/src/libcamera_app.cpp
+++ b/src/libcamera_app.cpp
@@ -331,7 +331,12 @@ void LibcameraApp::queueRequest(CompletedRequest *completed_request)
 
 	{
 		std::lock_guard<std::mutex> lock(control_mutex_);
+#if LIBCAMERA_VERSION_MINOR < 7
 		request->controls() = std::move(controls_);
+#else
+		request->controls().merge(controls_, ControlList::MergePolicy::OverwriteExisting);
+		controls_.clear();
+#endif//LIBCAMERA_VERSION_MINOR
 	}
 
 	if (camera_->queueRequest(request) < 0)


### PR DESCRIPTION
Fix #47 
Follows https://github.com/raspberrypi/rpicam-apps/commit/5bf5f80e7674cefd668e2f55614c65588cea7dd9